### PR TITLE
Add new CSS handle and update styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CSS handle to Step Group's checkout label: `stepGroupCheckoutLabel`.
+
+### Changed
+
+- Updated styles of Step Group's wrapper.
+
 ## [0.2.0] - 2020-03-03
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,3 +76,4 @@ regarding using CSS classes for store customization.
 | --- |
 | `stepGroupWrapper` |
 | `stepGroupList` |
+| `stepGroupCheckoutLabel` |

--- a/react/StepGroup.tsx
+++ b/react/StepGroup.tsx
@@ -49,7 +49,7 @@ export const useStepContext = () => {
   return value
 }
 
-const classes = ['stepGroupWrapper', 'stepGroupList']
+const classes = ['stepGroupWrapper', 'stepGroupList', 'stepGroupCheckoutLabel']
 
 const StepGroup: React.FC = ({ children }) => {
   const [activeElement, setActive] = useState<HTMLLIElement | undefined>(
@@ -105,8 +105,12 @@ const StepGroup: React.FC = ({ children }) => {
 
   return (
     <ctx.Provider value={contextValue}>
-      <div className={`${cssHandles.stepGroupWrapper} ph3`}>
-        <h3 className="c-muted-1 f5 mb5 mb6-ns mt0">Checkout</h3>
+      <div className={cssHandles.stepGroupWrapper}>
+        <h3
+          className={`${cssHandles.stepGroupCheckoutLabel} c-muted-1 f5 mb5 mb6-ns mt7 pt4`}
+        >
+          Checkout
+        </h3>
         <ol className={`${cssHandles.stepGroupList} pa0 ma0`}>{children}</ol>
       </div>
     </ctx.Provider>


### PR DESCRIPTION
#### What problem is this solving?
Add a new CSS handle for the Checkout label and update the step group wrapper styles.

[Related clubhouse story](https://app.clubhouse.io/vtex/story/32812/layout-da-p%C3%A1gina-de-checkout-no-io)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout)

#### Checklist/Reminders

- [x] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/10223856/76088441-d4e91680-5f96-11ea-939e-9d89b4af3f71.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->