### PR TITLE
Add checkout payment component in payment step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Payment component from `vtex.checkout-payment` app.
+
 ## [0.4.0] - 2020-03-09
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "vtex.styleguide": "9.x",
     "vtex.css-handles": "0.x",
-    "vtex.checkout-container": "0.x"
+    "vtex.checkout-container": "0.x",
+    "vtex.checkout-payment": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/PaymentStep.tsx
+++ b/react/PaymentStep.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { ButtonPlain, IconEdit } from 'vtex.styleguide'
 import { Router } from 'vtex.checkout-container'
+import { Payment } from 'vtex.checkout-payment'
 
 import IconMastercard from './icons/IconMastercard'
 import Step from './Step'
@@ -28,12 +29,19 @@ const PaymentStep: React.FC = () => {
       }
       active={!!match}
     >
-      <div className="flex items-center">
-        <IconMastercard />
-        <span className="c-base ml5">
-          Credit Card &middot; &middot; &middot; &middot; 0000
-        </span>
-      </div>
+      <Router.Switch>
+        <Router.Route path={PAYMENT_ROUTE}>
+          <Payment />
+        </Router.Route>
+        <Router.Route path="*">
+          <div className="flex items-center">
+            <IconMastercard />
+            <span className="c-base ml5">
+              Credit Card &middot; &middot; &middot; &middot; 0000
+            </span>
+          </div>
+        </Router.Route>
+      </Router.Switch>
     </Step>
   )
 }

--- a/react/Step.tsx
+++ b/react/Step.tsx
@@ -106,7 +106,7 @@ const Step: React.FC<StepProps> = ({ children, title, active = false }) => {
             'dn db-ns bg-muted-4 nt4 nb6 nb7-ns mh5'
           )}
         />
-        <div className={classNames(handles.stepContent, 'ml5-ns')}>
+        <div className={classNames(handles.stepContent, 'ml5-ns w-100')}>
           {children}
         </div>
       </div>

--- a/react/package.json
+++ b/react/package.json
@@ -13,10 +13,10 @@
     "@types/node": "^13.7.2",
     "@types/react": "^16.9.20",
     "@types/react-dom": "^16.9.5",
-    "vtex.checkout-container": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.2.0+build1583769921/public/@types/vtex.checkout-container",
-    "vtex.checkout-payment": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.3.0+build1583865529/public/@types/vtex.checkout-payment",
+    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.3.0/public/@types/vtex.checkout-container",
+    "vtex.checkout-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.3.0/public/@types/vtex.checkout-payment",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.0/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide"
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -13,9 +13,10 @@
     "@types/node": "^13.7.2",
     "@types/react": "^16.9.20",
     "@types/react-dom": "^16.9.5",
-    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.1.0/public/@types/vtex.checkout-container",
-    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.1/public/@types/vtex.css-handles",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.93.0/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.1/public/@types/vtex.styleguide"
+    "vtex.checkout-container": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.2.0+build1583769921/public/@types/vtex.checkout-container",
+    "vtex.checkout-payment": "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.3.0+build1583865529/public/@types/vtex.checkout-payment",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.0/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide"
   }
 }

--- a/react/typings/vtex.checkout-payment.d.ts
+++ b/react/typings/vtex.checkout-payment.d.ts
@@ -1,0 +1,3 @@
+declare module 'vtex.checkout-payment/Payment' {
+  export { default } from 'vtex.checkout-payment/react/Payment'
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -190,18 +190,22 @@ shallow-equal@^1.2.1:
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
   integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
-"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.1.0/public/@types/vtex.checkout-container":
-  version "0.1.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.1.0/public/@types/vtex.checkout-container#c0e6d7d422f2a830f21704ba5f2ce9326539c708"
+"vtex.checkout-container@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.2.0+build1583769921/public/@types/vtex.checkout-container":
+  version "0.2.0"
+  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.2.0+build1583769921/public/@types/vtex.checkout-container#b1ae8495d6fd2e12a36ba134bb127358f37ea04e"
 
-"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.1/public/@types/vtex.css-handles":
-  version "0.4.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.1/public/@types/vtex.css-handles#16fe9485e8e7183b94f28496ed8cdd741c83f227"
+"vtex.checkout-payment@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.3.0+build1583865529/public/@types/vtex.checkout-payment":
+  version "0.3.0"
+  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.3.0+build1583865529/public/@types/vtex.checkout-payment#6b8e5c294ca20461f295769f18054678e037526b"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.93.0/public/@types/vtex.render-runtime":
-  version "8.93.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.93.0/public/@types/vtex.render-runtime#db45939964edf7c8a3adf12580901c50ad1a0c24"
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
+  version "0.4.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles#62ee61d1bb9efdc919e5cf4bb44fabcf9050d255"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.1/public/@types/vtex.styleguide":
-  version "9.112.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.1/public/@types/vtex.styleguide#70b4766493bb03695fb7daf92c4b79236c9830b5"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.0/public/@types/vtex.render-runtime":
+  version "8.95.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.0/public/@types/vtex.render-runtime#83fadce267c67a81eb99f4cc77afbd54d4c9b650"
+
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide":
+  version "9.112.14"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide#3ad332c14335505fe50545af11331a2d54e681ae"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -190,13 +190,13 @@ shallow-equal@^1.2.1:
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
   integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
-"vtex.checkout-container@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.2.0+build1583769921/public/@types/vtex.checkout-container":
-  version "0.2.0"
-  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.2.0+build1583769921/public/@types/vtex.checkout-container#b1ae8495d6fd2e12a36ba134bb127358f37ea04e"
-
-"vtex.checkout-payment@https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.3.0+build1583865529/public/@types/vtex.checkout-payment":
+"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.3.0/public/@types/vtex.checkout-container":
   version "0.3.0"
-  resolved "https://lucas--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.3.0+build1583865529/public/@types/vtex.checkout-payment#6b8e5c294ca20461f295769f18054678e037526b"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.3.0/public/@types/vtex.checkout-container#0ee786ff7e0c0b28723e628f7cf0f729bbd29c88"
+
+"vtex.checkout-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.3.0/public/@types/vtex.checkout-payment":
+  version "0.3.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.3.0/public/@types/vtex.checkout-payment#fc94e73cb2534041082f366ec8b6b02ef99551b0"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
   version "0.4.2"
@@ -206,6 +206,6 @@ shallow-equal@^1.2.1:
   version "8.95.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.95.0/public/@types/vtex.render-runtime#83fadce267c67a81eb99f4cc77afbd54d4c9b650"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide":
-  version "9.112.14"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.14/public/@types/vtex.styleguide#3ad332c14335505fe50545af11331a2d54e681ae"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide":
+  version "9.112.15"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.112.15/public/@types/vtex.styleguide#1859832d974e0b0b82dff8ed086f005907058dda"


### PR DESCRIPTION
#### What problem is this solving?
Adds the checkout payment component in the payment step, so the user can save a new credit card.

#### How should this be manually tested?
[Workspace](https://lucas--checkoutio.myvtex.com/checkout/#/payment)

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/10223856/76352179-60dba500-62ed-11ea-9c43-e5e14722f5a7.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->