### PR TITLE
Fix font weight on Step component title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,49 +5,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Font weight of step title.
 
 ## [0.5.1] - 2020-03-24
-
 ### Changed
-
 - Split `Step`'s `title` prop into `title` and `actionButton`.
 
 ### Fixed
-
 - Font size of steps titles.
 
 ## [0.5.0] - 2020-03-11
-
 ### Added
-
 - Payment component from `vtex.checkout-payment` app.
 
 ## [0.4.0] - 2020-03-09
-
 ### Added
-
 - CSS handles to Step component: `step`, `stepTitle`, `indicator`, `indicatorActive`,
   `indicatorInactive`, `stepContentWrapper`, `stepDivider` and `stepContent`.
 - Styles for mobile resolutions.
 
 ## [0.3.0] - 2020-03-09
-
 ### Added
-
 - CSS handle to Step Group's checkout label: `stepGroupCheckoutLabel`.
 
 ### Changed
-
 - Updated styles of Step Group's wrapper.
 
 ## [0.2.0] - 2020-03-03
-
 ### Added
-
 - Components for default steps included in checkout: profile, shipping and payment.
 
 ## [0.1.0] - 2020-02-21
-
 ### Added
-
 - Initial `StepGroup` and `Step` components.

--- a/react/Step.tsx
+++ b/react/Step.tsx
@@ -97,7 +97,7 @@ const Step: React.FC<StepProps> = ({
           }
         )}
       >
-        <h2 className={classNames('mv0', { f5: !active, f4: active })}>
+        <h2 className={classNames('mv0 fw6', { f5: !active, f4: active })}>
           {title}
         </h2>
         {actionButton && <div className="pl4">{actionButton}</div>}


### PR DESCRIPTION
#### What problem is this solving?
Follow up on design review.

[Related clubhouse story](https://app.clubhouse.io/vtex/story/34395/corre%C3%A7%C3%A3o-de-inconsistencias-de-design-no-checkout)

#### How should this be manually tested?
[Workspace](https://chkio--checkoutio.myvtex.com/checkout)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/10223856/77576710-64a62480-6eb4-11ea-8190-564d90799b8c.png)

The font-weight of the title was slightly "lowered".

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->