### PR TITLE
Fix border width collapsing on Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Step border collapsing on Firefox.
 
 ## [0.6.0] - 2020-03-31
 ### Added

--- a/react/Step.tsx
+++ b/react/Step.tsx
@@ -69,6 +69,8 @@ const Step: React.FC<StepProps> = ({
 
   const isActive = activeIndex === index
 
+  const borderWidth = (index ?? 0) < lastIndex ? 1 : 0
+
   return (
     <li
       className={classNames(handles.step, 'flex flex-wrap items-center')}
@@ -113,7 +115,7 @@ const Step: React.FC<StepProps> = ({
         )}
       >
         <div
-          style={{ width: (index ?? 0) < lastIndex ? 1 : 0 }}
+          style={{ width: borderWidth, minWidth: borderWidth }}
           className={classNames(
             handles.stepDivider,
             'dn db-ns bg-muted-4 nt4 nb6 nb7-ns mh5',


### PR DESCRIPTION
#### What problem is this solving?

This fixes a minor issue observed on Firefox and on relatively high resolutions (>= 1920px) where the border that separates the steps was collapsed and was not visible.

![image](https://user-images.githubusercontent.com/10223856/81211768-3edb6780-8faa-11ea-98b4-83b3887f9beb.png)

> For the red border I manually added a `min-width` in the element and that color so it would be visible, but you can see that the border from shipping to payment isn't.

#### How should this be manually tested?

[Workspace](https://lucas--checkoutio.myvtex.com/checkout/#/payment). You will need to access it from Firefox and in a big resolution (1920px is fine).

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/10223856/81212261-04be9580-8fab-11ea-8348-b9429b371bf6.png)

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->