### PR TITLE
Add testId to Step action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Use testId on `Step` action button. 
 
 ## [0.8.0] - 2020-05-19
 ### Added

--- a/react/PaymentStep.tsx
+++ b/react/PaymentStep.tsx
@@ -17,6 +17,7 @@ const PaymentStep: React.FC = () => {
   return (
     <Step
       title={<FormattedMessage id="store/checkout-payment-step-title" />}
+      data-testid="edit-payment-step"
       actionButton={
         !match && (
           <ButtonPlain

--- a/react/ProfileStep.tsx
+++ b/react/ProfileStep.tsx
@@ -17,6 +17,7 @@ const ProfileStep: React.FC = () => {
   return (
     <Step
       title={<FormattedMessage id="store/checkout-profile-step-title" />}
+      data-testid="edit-profile-step"
       actionButton={
         !match && (
           <ButtonPlain

--- a/react/ShippingStep.tsx
+++ b/react/ShippingStep.tsx
@@ -17,6 +17,7 @@ const ShippingStep: React.FC = () => {
   return (
     <Step
       title={<FormattedMessage id="store/checkout-shipping-step-title" />}
+      data-testid="edit-shipping-step"
       actionButton={
         !match && (
           <ButtonPlain

--- a/react/Step.tsx
+++ b/react/Step.tsx
@@ -40,6 +40,7 @@ const useStepIndicator = (elementRef: React.RefObject<HTMLLIElement>) => {
 
 interface StepProps {
   title: React.ReactNode
+  'data-testid'?: string
   actionButton?: React.ReactNode
   active?: boolean
 }
@@ -47,6 +48,7 @@ interface StepProps {
 const Step: React.FC<StepProps> = ({
   children,
   title,
+  'data-testid': dataTestId,
   active = false,
   actionButton = null,
 }) => {
@@ -102,7 +104,11 @@ const Step: React.FC<StepProps> = ({
         <h2 className={classNames('mv0 fw6', { f5: !active, f4: active })}>
           {title}
         </h2>
-        {actionButton && <div className="pl4">{actionButton}</div>}
+        {actionButton && (
+          <div className="pl4" data-testid={dataTestId}>
+            {actionButton}
+          </div>
+        )}
       </span>
       <div
         className={classNames(


### PR DESCRIPTION
#### What problem is this solving?

Add testIds to improve e2e tests development. See [this](https://github.com/vtex-apps/checkout-io-tests/pull/4#discussion_r429239714).

#### How should this be manually tested?

Clone [this branch](https://github.com/vtex-apps/checkout-io-tests/pull/4) locally and run yarn e2e. Don't forget to login on VTEX (toolbelt). It should pass every profile test.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
✔️ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

I don't really like how it's done. Maybe the `testId` should be inside the `ButtonPlain`, not on the whole step component. For example, currently you can click to _enter/edit_ a group step using the `testId`, but not leave (but this "leave" button should really exist?).