### PR TITLE
Feature free purchase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Do not show `IconEdit` Component if the purchase is free
 
 ## [0.10.0] - 2021-01-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Do not show `IconEdit` Component if the purchase is free
+- Do not show Icon Edit if the purchase is free
 
 ## [0.10.0] - 2021-01-05
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,8 @@
     "vtex.checkout-shipping": "0.x",
     "vtex.css-handles": "0.x",
     "vtex.order-manager": "0.x",
-    "vtex.styleguide": "9.x"
+    "vtex.styleguide": "9.x",
+    "vtex.order-payment": "0.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/react/PaymentStep.tsx
+++ b/react/PaymentStep.tsx
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl'
 import { ButtonPlain, IconEdit } from 'vtex.styleguide'
 import { Router, routes } from 'vtex.checkout-container'
 import { Payment, PaymentSummary } from 'vtex.checkout-payment'
+import { useOrderPayment } from 'vtex.order-payment/OrderPayment'
 
 import Step from './Step'
 
@@ -11,13 +12,16 @@ const { useHistory, useRouteMatch } = Router
 const PaymentStep: React.FC = () => {
   const history = useHistory()
   const match = useRouteMatch(routes.PAYMENT)
+  const { isFreePurchase } = useOrderPayment()
+
+  const shouldShowEditButton = !match && !isFreePurchase
 
   return (
     <Step
       title={<FormattedMessage id="store/checkout-payment-step-title" />}
       data-testid="edit-payment-step"
       actionButton={
-        !match && (
+        shouldShowEditButton && (
           <ButtonPlain onClick={() => history.push(routes.PAYMENT)}>
             <IconEdit solid />
           </ButtonPlain>

--- a/react/package.json
+++ b/react/package.json
@@ -14,13 +14,13 @@
     "@types/react": "^16.9.20",
     "@types/react-dom": "^16.9.5",
     "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container",
-    "vtex.checkout-payment": "https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.9.0+build1605191438/public/@types/vtex.checkout-payment",
+    "vtex.checkout-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.11.3/public/@types/vtex.checkout-payment",
     "vtex.checkout-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile",
-    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.4.1/public/@types/vtex.checkout-shipping",
+    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager",
-    "vtex.order-payment": "https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.order-payment@0.7.0+build1605185470/public/@types/vtex.order-payment",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide"
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
+    "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -13,13 +13,14 @@
     "@types/node": "^13.7.2",
     "@types/react": "^16.9.20",
     "@types/react-dom": "^16.9.5",
-    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.0/public/@types/vtex.checkout-container",
-    "vtex.checkout-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.8.0/public/@types/vtex.checkout-payment",
+    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container",
+    "vtex.checkout-payment": "https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.9.0+build1605191438/public/@types/vtex.checkout-payment",
     "vtex.checkout-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile",
-    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.2.3/public/@types/vtex.checkout-shipping",
-    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles",
-    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide"
+    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.4.1/public/@types/vtex.checkout-shipping",
+    "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
+    "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager",
+    "vtex.order-payment": "https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.order-payment@0.7.0+build1605185470/public/@types/vtex.order-payment",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide"
   }
 }

--- a/react/typings/vtex.order-payment.d.ts
+++ b/react/typings/vtex.order-payment.d.ts
@@ -1,0 +1,4 @@
+declare module 'vtex.order-payment/OrderPayment' {
+  export * from 'vtex.order-payment/react/OrderPayment'
+  export { default } from 'vtex.order-payment/react/OrderPayment'
+}

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -194,34 +194,34 @@ shallow-equal@^1.2.1:
   version "0.6.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container#a3862cecfeaf1af70e26f70e24a51224297e1138"
 
-"vtex.checkout-payment@https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.9.0+build1605191438/public/@types/vtex.checkout-payment":
-  version "0.9.0"
-  resolved "https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.9.0+build1605191438/public/@types/vtex.checkout-payment#502f426eac5ae8342a11b6989ba65106fb2e6fb4"
+"vtex.checkout-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.11.3/public/@types/vtex.checkout-payment":
+  version "0.11.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.11.3/public/@types/vtex.checkout-payment#c78f7e2c95f1c81e212279941be3716daad233e8"
 
 "vtex.checkout-profile@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile":
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile#e3dc590c2de3d774dd46be234b6636715e88ab32"
 
-"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.4.1/public/@types/vtex.checkout-shipping":
-  version "0.4.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.4.1/public/@types/vtex.checkout-shipping#76abba2303cb81b855495285a2dd26e8cc6d3ddd"
+"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping":
+  version "0.6.5"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping#b7ea02ac0236010424972f1408e031fa8302ae09"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager":
-  version "0.8.7"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager#d666dbf9c6d630dba38ac26e815ffaa3811933df"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager":
+  version "0.9.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager#95626778e7cff8c8e70f0a3b09348937043f6d21"
 
-"vtex.order-payment@https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.order-payment@0.7.0+build1605185470/public/@types/vtex.order-payment":
-  version "0.7.0"
-  resolved "https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.order-payment@0.7.0+build1605185470/public/@types/vtex.order-payment#b366f69bb8ec86316c913fdc6fc37cbbd19a91d2"
+"vtex.order-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment":
+  version "0.8.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment#916bba03b2fb9c653d1dc1503cfd0a3d3a47b451"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime":
-  version "8.124.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime#8158e34bd24b4a51cb5d463eeef4e37af626c2d5"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime":
+  version "8.126.7"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime#bf00fb2ef41c5158c566c12dc6dd9dd0d5c2a9e9"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide":
-  version "9.133.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide#0b2020bfe4732e76f7dc6fcff4a77ba81f211c5d"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
+  version "9.134.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide#7210ed4908f4e6482d2499d71c4cfcc21e3dfd6a"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -190,34 +190,38 @@ shallow-equal@^1.2.1:
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
   integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
-"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.0/public/@types/vtex.checkout-container":
-  version "0.6.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.0/public/@types/vtex.checkout-container#a79170cf2fc14601514850967bf954a5cbcf672f"
+"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container":
+  version "0.6.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container#a3862cecfeaf1af70e26f70e24a51224297e1138"
 
-"vtex.checkout-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.8.0/public/@types/vtex.checkout-payment":
-  version "0.8.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.8.0/public/@types/vtex.checkout-payment#1706a2a4ca0db452db75f74bb011edf80c81a315"
+"vtex.checkout-payment@https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.9.0+build1605191438/public/@types/vtex.checkout-payment":
+  version "0.9.0"
+  resolved "https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-payment@0.9.0+build1605191438/public/@types/vtex.checkout-payment#502f426eac5ae8342a11b6989ba65106fb2e6fb4"
 
 "vtex.checkout-profile@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile":
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile#e3dc590c2de3d774dd46be234b6636715e88ab32"
 
-"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.2.3/public/@types/vtex.checkout-shipping":
-  version "0.2.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.2.3/public/@types/vtex.checkout-shipping#63cc0fce81cb221c045da8789b2bf1257913b93b"
+"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.4.1/public/@types/vtex.checkout-shipping":
+  version "0.4.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.4.1/public/@types/vtex.checkout-shipping#76abba2303cb81b855495285a2dd26e8cc6d3ddd"
 
-"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles":
-  version "0.4.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.2/public/@types/vtex.css-handles#62ee61d1bb9efdc919e5cf4bb44fabcf9050d255"
+"vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
+  version "0.4.4"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles#8c45c6decf9acd2b944e07261686decff93d6422"
 
-"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager":
-  version "0.8.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.5/public/@types/vtex.order-manager#1f01414540d02e2ea7e41e73edaf431d407a9985"
+"vtex.order-manager@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager":
+  version "0.8.7"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.8.7/public/@types/vtex.order-manager#d666dbf9c6d630dba38ac26e815ffaa3811933df"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime":
-  version "8.111.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.111.0/public/@types/vtex.render-runtime#01b2ce53d1aa2a974f5229c61bd9c83b43a86d76"
+"vtex.order-payment@https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.order-payment@0.7.0+build1605185470/public/@types/vtex.order-payment":
+  version "0.7.0"
+  resolved "https://pedrocheckout--extensions.myvtex.com/_v/private/typings/linked/v1/vtex.order-payment@0.7.0+build1605185470/public/@types/vtex.order-payment#b366f69bb8ec86316c913fdc6fc37cbbd19a91d2"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide":
-  version "9.124.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.124.2/public/@types/vtex.styleguide#23f1937bebae169c1d110594a4af3cc3ef05c601"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime":
+  version "8.124.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.124.3/public/@types/vtex.render-runtime#8158e34bd24b4a51cb5d463eeef4e37af626c2d5"
+
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide":
+  version "9.133.2"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.133.2/public/@types/vtex.styleguide#0b2020bfe4732e76f7dc6fcff4a77ba81f211c5d"


### PR DESCRIPTION
#### What problem is this solving?

Context [here](https://github.com/vtex-apps/order-payment/pull/13)

Do not show Icon Edit if the purchase is free.

#### How should this be manually tested?

Choose the account `pilateslovers`. 
[App Store](https://pedrocheckout--extensions.myvtex.com/vtex-facebook-pixel/p)

I'm getting some issues to test the flow using `checkoutio` account because I can't choose a free shipping.  
[Checkout IO](https://pedrocheckout--checkoutio.myvtex.com/Produto-gratis/p)


#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).


#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️  | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

