### PR TITLE
Add css handle to Alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- CSS handle to Step Group's alert: `stepGroupAlert`.
 
 ## [0.9.0] - 2020-07-13
 

--- a/react/StepGroup.tsx
+++ b/react/StepGroup.tsx
@@ -54,7 +54,12 @@ export const useStepContext = () => {
   return value
 }
 
-const classes = ['stepGroupWrapper', 'stepGroupList', 'stepGroupCheckoutLabel']
+const classes = [
+  'stepGroupWrapper',
+  'stepGroupList',
+  'stepGroupCheckoutLabel',
+  'stepGroupAlert',
+] as const
 
 const StepGroup: React.FC = ({ children }) => {
   const { orderForm } = useOrderForm()
@@ -125,7 +130,7 @@ const StepGroup: React.FC = ({ children }) => {
           <FormattedMessage id="store/checkout-label" />
         </h3>
         {alertOpen && (
-          <div className="mb5 mb6-ns">
+          <div className={`${cssHandles.stepGroupAlert} mb5 mb6-ns`}>
             <Alert
               type="success"
               closeIconLabel={intl.formatMessage({


### PR DESCRIPTION
#### What problem is this solving?

Add CSS handle to Step Group's alert: `stepGroupAlert`.

Customization In app store theme: 
```
.stepGroupAlert {
  display: none;
}
```
#### How should this be manually tested?
Try to buy an app for `pilateslovers` account. 

[Workspace](https://pedrocheckout--extensions.myvtex.com/vtex-facebook-pixel/p)

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->

#### Notes

<!-- Put any relevant information that doesn't fit in the other sections here. -->
