### PR TITLE
CHK-544: Add new address-step block

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] Updated `README.md`.
 - [ ] Updated `CHANGELOG.md`.
-- [ ] Linked this PR to a Clubhouse story (if applicable).
+- [ ] Linked this PR to a Jira story (if applicable).
 - [ ] Updated/created tests (important for bug fixes).
 - [ ] Deleted the workspace after merging this PR (if applicable).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New address step block.
 
 ## [0.11.0] - 2021-01-18
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -17,8 +17,9 @@
     "vtex.checkout-shipping": "0.x",
     "vtex.css-handles": "0.x",
     "vtex.order-manager": "0.x",
-    "vtex.styleguide": "9.x",
-    "vtex.order-payment": "0.x"
+    "vtex.order-payment": "0.x",
+    "vtex.order-shipping": "0.x",
+    "vtex.styleguide": "9.x"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -4,5 +4,6 @@
   "store/checkout-autofill-close-label": "Close",
   "store/checkout-profile-step-title": "Profile",
   "store/checkout-shipping-step-title": "Shipping",
+  "store/checkout-address-step-title": "Address",
   "store/checkout-payment-step-title": "Payment"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -4,5 +4,6 @@
   "store/checkout-autofill-close-label": "Cerca",
   "store/checkout-profile-step-title": "Perfil",
   "store/checkout-shipping-step-title": "Entrega",
+  "store/checkout-address-step-title": "Dirección",
   "store/checkout-payment-step-title": "Pago"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -4,5 +4,6 @@
   "store/checkout-autofill-close-label": "Fechar",
   "store/checkout-profile-step-title": "Perfil",
   "store/checkout-shipping-step-title": "Entrega",
+  "store/checkout-address-step-title": "Endereço",
   "store/checkout-payment-step-title": "Pagamento"
 }

--- a/react/AddressStep.tsx
+++ b/react/AddressStep.tsx
@@ -3,16 +3,30 @@ import { FormattedMessage } from 'react-intl'
 import { ButtonPlain, IconEdit } from 'vtex.styleguide'
 import { Router, ContainerContext, routes } from 'vtex.checkout-container'
 import { AddressSummary, ShippingAddress } from 'vtex.checkout-shipping'
+import { OrderForm } from 'vtex.order-manager'
+import { OrderShipping } from 'vtex.order-shipping'
 
 import Step from './Step'
 
+const { useOrderForm } = OrderForm
+const { useOrderShipping } = OrderShipping
 const { useHistory, useRouteMatch } = Router
 const { useCheckoutContainer } = ContainerContext
 
 const AddressStep: React.FC = () => {
   const history = useHistory()
   const match = useRouteMatch(routes.ADDRESS)
-  const { isAddressEditable } = useCheckoutContainer()
+  const { requestLogin, isAddressEditable } = useCheckoutContainer()
+  const { orderForm } = useOrderForm()
+  const { selectedAddress } = useOrderShipping()
+
+  const handleAddressEdit = () => {
+    if (orderForm.canEditData || selectedAddress?.isDisposable) {
+      history.push(routes.ADDRESS)
+    } else {
+      requestLogin()
+    }
+  }
 
   return (
     <Step
@@ -21,7 +35,7 @@ const AddressStep: React.FC = () => {
       actionButton={
         !match &&
         isAddressEditable && (
-          <ButtonPlain onClick={() => history.push(routes.ADDRESS)}>
+          <ButtonPlain onClick={handleAddressEdit}>
             <IconEdit solid />
           </ButtonPlain>
         )

--- a/react/AddressStep.tsx
+++ b/react/AddressStep.tsx
@@ -2,26 +2,26 @@ import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { ButtonPlain, IconEdit } from 'vtex.styleguide'
 import { Router, ContainerContext, routes } from 'vtex.checkout-container'
-import { ShippingSummary, ShippingForm } from 'vtex.checkout-shipping'
+import { AddressSummary, ShippingAddress } from 'vtex.checkout-shipping'
 
 import Step from './Step'
 
 const { useHistory, useRouteMatch } = Router
 const { useCheckoutContainer } = ContainerContext
 
-const ShippingStep: React.FC = () => {
+const AddressStep: React.FC = () => {
   const history = useHistory()
-  const match = useRouteMatch(routes.SHIPPING)
-  const { isShippingEditable } = useCheckoutContainer()
+  const match = useRouteMatch(routes.ADDRESS)
+  const { isAddressEditable } = useCheckoutContainer()
 
   return (
     <Step
-      title={<FormattedMessage id="store/checkout-shipping-step-title" />}
-      data-testid="edit-shipping-step"
+      title={<FormattedMessage id="store/checkout-address-step-title" />}
+      data-testid="edit-address-step"
       actionButton={
         !match &&
-        isShippingEditable && (
-          <ButtonPlain onClick={() => history.push(routes.SHIPPING)}>
+        isAddressEditable && (
+          <ButtonPlain onClick={() => history.push(routes.ADDRESS)}>
             <IconEdit solid />
           </ButtonPlain>
         )
@@ -29,15 +29,15 @@ const ShippingStep: React.FC = () => {
       active={!!match}
     >
       <Router.Switch>
-        <Router.Route path={routes.SHIPPING}>
-          <ShippingForm />
+        <Router.Route path={routes.ADDRESS}>
+          <ShippingAddress />
         </Router.Route>
         <Router.Route path="*">
-          <ShippingSummary />
+          <AddressSummary />
         </Router.Route>
       </Router.Switch>
     </Step>
   )
 }
 
-export default ShippingStep
+export default AddressStep

--- a/react/PaymentStep.tsx
+++ b/react/PaymentStep.tsx
@@ -1,20 +1,22 @@
 import React from 'react'
 import { FormattedMessage } from 'react-intl'
 import { ButtonPlain, IconEdit } from 'vtex.styleguide'
-import { Router, routes } from 'vtex.checkout-container'
+import { Router, ContainerContext, routes } from 'vtex.checkout-container'
 import { Payment, PaymentSummary } from 'vtex.checkout-payment'
 import { useOrderPayment } from 'vtex.order-payment/OrderPayment'
 
 import Step from './Step'
 
 const { useHistory, useRouteMatch } = Router
+const { useCheckoutContainer } = ContainerContext
 
 const PaymentStep: React.FC = () => {
   const history = useHistory()
   const match = useRouteMatch(routes.PAYMENT)
   const { isFreePurchase } = useOrderPayment()
+  const { isPaymentEditable } = useCheckoutContainer()
 
-  const shouldShowEditButton = !match && !isFreePurchase
+  const shouldShowEditButton = !match && !isFreePurchase && isPaymentEditable
 
   return (
     <Step

--- a/react/ProfileStep.tsx
+++ b/react/ProfileStep.tsx
@@ -15,7 +15,7 @@ const ProfileStep: React.FC = () => {
   const { orderForm } = useOrderForm()
   const history = useHistory()
   const match = useRouteMatch(routes.PROFILE)
-  const { requestLogin } = useCheckoutContainer()
+  const { requestLogin, isProfileEditable } = useCheckoutContainer()
 
   const handleProfileEdit = () => {
     if (orderForm.canEditData) {
@@ -30,7 +30,8 @@ const ProfileStep: React.FC = () => {
       title={<FormattedMessage id="store/checkout-profile-step-title" />}
       data-testid="edit-profile-step"
       actionButton={
-        !match && (
+        !match &&
+        isProfileEditable && (
           <ButtonPlain onClick={handleProfileEdit}>
             <IconEdit solid />
           </ButtonPlain>

--- a/react/package.json
+++ b/react/package.json
@@ -16,10 +16,11 @@
     "vtex.checkout-container": "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.6.2+build1612208052/public/@types/vtex.checkout-container",
     "vtex.checkout-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.12.0/public/@types/vtex.checkout-payment",
     "vtex.checkout-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile",
-    "vtex.checkout-shipping": "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612205256/public/@types/vtex.checkout-shipping",
+    "vtex.checkout-shipping": "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612288862/public/@types/vtex.checkout-shipping",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
     "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment",
+    "vtex.order-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping",
     "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide"
   }

--- a/react/package.json
+++ b/react/package.json
@@ -13,14 +13,14 @@
     "@types/node": "^13.7.2",
     "@types/react": "^16.9.20",
     "@types/react-dom": "^16.9.5",
-    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container",
-    "vtex.checkout-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.11.3/public/@types/vtex.checkout-payment",
+    "vtex.checkout-container": "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.6.2+build1612208052/public/@types/vtex.checkout-container",
+    "vtex.checkout-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.12.0/public/@types/vtex.checkout-payment",
     "vtex.checkout-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile",
-    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping",
+    "vtex.checkout-shipping": "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612205256/public/@types/vtex.checkout-shipping",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
     "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide"
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -13,15 +13,15 @@
     "@types/node": "^13.7.2",
     "@types/react": "^16.9.20",
     "@types/react-dom": "^16.9.5",
-    "vtex.checkout-container": "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.6.2+build1612208052/public/@types/vtex.checkout-container",
-    "vtex.checkout-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.12.0/public/@types/vtex.checkout-payment",
+    "vtex.checkout-container": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container",
+    "vtex.checkout-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.13.0/public/@types/vtex.checkout-payment",
     "vtex.checkout-profile": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile",
-    "vtex.checkout-shipping": "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612288862/public/@types/vtex.checkout-shipping",
+    "vtex.checkout-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.7.1/public/@types/vtex.checkout-shipping",
     "vtex.css-handles": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles",
     "vtex.order-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-manager@0.9.0/public/@types/vtex.order-manager",
     "vtex.order-payment": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment",
     "vtex.order-shipping": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime",
-    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide"
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime",
+    "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide"
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -190,21 +190,21 @@ shallow-equal@^1.2.1:
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
   integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
-"vtex.checkout-container@https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.6.2+build1612208052/public/@types/vtex.checkout-container":
-  version "0.6.2"
-  resolved "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.6.2+build1612208052/public/@types/vtex.checkout-container#98a452311dd1372a858dc876bd1d443b68ceb0b5"
+"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container":
+  version "0.7.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.7.0/public/@types/vtex.checkout-container#4c06bc1357567e7dd6cff1f18c1ac15c64fd72c9"
 
-"vtex.checkout-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.12.0/public/@types/vtex.checkout-payment":
-  version "0.12.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.12.0/public/@types/vtex.checkout-payment#6639e365e8124b3390e83fa41ca89d1d5c3361d9"
+"vtex.checkout-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.13.0/public/@types/vtex.checkout-payment":
+  version "0.13.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.13.0/public/@types/vtex.checkout-payment#771265233b3b6f8aa9f01b921ac41ca70e479a57"
 
 "vtex.checkout-profile@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile":
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile#e3dc590c2de3d774dd46be234b6636715e88ab32"
 
-"vtex.checkout-shipping@https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612288862/public/@types/vtex.checkout-shipping":
-  version "0.6.6"
-  resolved "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612288862/public/@types/vtex.checkout-shipping#451c3404341c2b6f678d389ed4908fc286c21394"
+"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.7.1/public/@types/vtex.checkout-shipping":
+  version "0.7.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.7.1/public/@types/vtex.checkout-shipping#198d9c59b94c37a6e309b8dae929d3d485f2541c"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"
@@ -222,10 +222,10 @@ shallow-equal@^1.2.1:
   version "0.7.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping#4d020086b9da30807f0b6ec059c30d5a8727889d"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime":
-  version "8.126.10"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime#1eb37d8ef0fcaef17060306f6d5dff6d9e404d39"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime":
+  version "8.126.11"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.11/public/@types/vtex.render-runtime#aceb734766093b56954ec19a074574b4c2c95242"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide":
-  version "9.135.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide#ed8d203eff74ed072b6e2f6ddb66d0c92b797ade"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide":
+  version "9.135.3"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.3/public/@types/vtex.styleguide#744a8674d69a56594de969da36b263f94c9de66f"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -190,21 +190,21 @@ shallow-equal@^1.2.1:
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.1.tgz#4c16abfa56043aa20d050324efa68940b0da79da"
   integrity sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==
 
-"vtex.checkout-container@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container":
+"vtex.checkout-container@https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.6.2+build1612208052/public/@types/vtex.checkout-container":
   version "0.6.2"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-container@0.6.2/public/@types/vtex.checkout-container#a3862cecfeaf1af70e26f70e24a51224297e1138"
+  resolved "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-container@0.6.2+build1612208052/public/@types/vtex.checkout-container#98a452311dd1372a858dc876bd1d443b68ceb0b5"
 
-"vtex.checkout-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.11.3/public/@types/vtex.checkout-payment":
-  version "0.11.3"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.11.3/public/@types/vtex.checkout-payment#c78f7e2c95f1c81e212279941be3716daad233e8"
+"vtex.checkout-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.12.0/public/@types/vtex.checkout-payment":
+  version "0.12.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-payment@0.12.0/public/@types/vtex.checkout-payment#6639e365e8124b3390e83fa41ca89d1d5c3361d9"
 
 "vtex.checkout-profile@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile":
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile#e3dc590c2de3d774dd46be234b6636715e88ab32"
 
-"vtex.checkout-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping":
-  version "0.6.5"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-shipping@0.6.5/public/@types/vtex.checkout-shipping#b7ea02ac0236010424972f1408e031fa8302ae09"
+"vtex.checkout-shipping@https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612205256/public/@types/vtex.checkout-shipping":
+  version "0.6.6"
+  resolved "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612205256/public/@types/vtex.checkout-shipping#a25267d9b8d66bb317cc3db25564b70866c65d26"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"
@@ -218,10 +218,10 @@ shallow-equal@^1.2.1:
   version "0.8.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment#916bba03b2fb9c653d1dc1503cfd0a3d3a47b451"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime":
-  version "8.126.7"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.7/public/@types/vtex.render-runtime#bf00fb2ef41c5158c566c12dc6dd9dd0d5c2a9e9"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime":
+  version "8.126.10"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime#1eb37d8ef0fcaef17060306f6d5dff6d9e404d39"
 
-"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
-  version "9.134.1"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide#7210ed4908f4e6482d2499d71c4cfcc21e3dfd6a"
+"vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide":
+  version "9.135.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.135.1/public/@types/vtex.styleguide#ed8d203eff74ed072b6e2f6ddb66d0c92b797ade"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -202,9 +202,9 @@ shallow-equal@^1.2.1:
   version "0.3.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.checkout-profile@0.3.0/public/@types/vtex.checkout-profile#e3dc590c2de3d774dd46be234b6636715e88ab32"
 
-"vtex.checkout-shipping@https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612205256/public/@types/vtex.checkout-shipping":
+"vtex.checkout-shipping@https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612288862/public/@types/vtex.checkout-shipping":
   version "0.6.6"
-  resolved "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612205256/public/@types/vtex.checkout-shipping#a25267d9b8d66bb317cc3db25564b70866c65d26"
+  resolved "https://addr--checkoutio.myvtex.com/_v/private/typings/linked/v1/vtex.checkout-shipping@0.6.6+build1612288862/public/@types/vtex.checkout-shipping#451c3404341c2b6f678d389ed4908fc286c21394"
 
 "vtex.css-handles@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.css-handles@0.4.4/public/@types/vtex.css-handles":
   version "0.4.4"
@@ -217,6 +217,10 @@ shallow-equal@^1.2.1:
 "vtex.order-payment@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment":
   version "0.8.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-payment@0.8.0/public/@types/vtex.order-payment#916bba03b2fb9c653d1dc1503cfd0a3d3a47b451"
+
+"vtex.order-shipping@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping":
+  version "0.7.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-shipping@0.7.0/public/@types/vtex.order-shipping#4d020086b9da30807f0b6ec059c30d5a8727889d"
 
 "vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.10/public/@types/vtex.render-runtime":
   version "8.126.10"

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,5 +1,10 @@
 {
   "checkout-step-group": {
-    "children": ["profile-step", "shipping-step", "payment-step"]
+    "children": [
+      "profile-step",
+      "shipping-step",
+      "address-step",
+      "payment-step"
+    ]
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -13,6 +13,9 @@
   "shipping-step": {
     "component": "ShippingStep"
   },
+  "address-step": {
+    "component": "AddressStep"
+  },
   "payment-step": {
     "component": "PaymentStep"
   }


### PR DESCRIPTION
#### What problem is this solving?

Adds the `address-step` block, to be used inside checkout after the current shipping step.

#### How should this be manually tested?

[Workspace](https://addr--checkoutio.myvtex.com/cart/add?sku=289).

You can see the new address step block rendered inside step group.

#### Checklist/Reminders

- [ ] Updated `README.md`.
- [x] Updated `CHANGELOG.md`.
- [x] Linked this PR to a Jira story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Screenshots or example usage

#### Type of changes

<!--- Add a ✔️ where applicable -->
✔️ | Type of Change
---|---
_ | Bug fix <!-- a non-breaking change which fixes an issue -->
✔️ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
